### PR TITLE
Update buildPlugin to align with what is in the global library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,10 +28,9 @@
         String stageIdentifier = "${label}-${jdk}${jenkinsVersion ? '-' + jenkinsVersion : ''}"
         boolean first = tasks.size() == 1
         boolean skipTests = params?.tests?.skip
-        boolean reallyUseAci = (useAci && label == 'linux') || forceAci
-        boolean addToolEnv = !reallyUseAci
+        boolean addToolEnv = !useAci
 
-        if(reallyUseAci) {
+        if(useAci && (label == 'linux' || label == 'windows')) {
             String aciLabel = jdk == '8' ? 'maven' : 'maven-11'
             if(label == 'windows') {
                 aciLabel += "-windows"


### PR DESCRIPTION
Updated to follow what is in the buildPlugin.groovy from the global pipeline library.

Is there a reason that you aren't using buildPlugin() directly? Maybe something we could implement in the global library so we can keep a single source of buildPlugin?