### PR TITLE
Fix naming of mutations

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/grading/AutoGradingViewModel/index.properties
+++ b/plugin/src/main/resources/io/jenkins/plugins/grading/AutoGradingViewModel/index.properties
@@ -6,5 +6,5 @@ tooltip={0} of {1}
 title.total=Total Score
 title.tests=Test Results
 title.coverage=Code Coverage
-title.pit=PIT Mutations
+title.pit=Mutation Coverage
 title.analysis=Static Analysis


### PR DESCRIPTION
Use `Mutation Coverage` since other parsers may be used as well.